### PR TITLE
Toxic spikes can stack up to two times.

### DIFF
--- a/src/model/side.js
+++ b/src/model/side.js
@@ -9,7 +9,8 @@ const clean = x => x.replace(/move:/gi, '').replace(/ /g, '').toLowerCase();
 // some effects can stack multiple times.
 const STACKS = {
   [SideConditions.SPIKES]: 3,
-  [SideConditions.STEALTHROCK]: 3
+  [SideConditions.STEALTHROCK]: 3,
+  [SideConditions.TOXICSPIKES]: 2
 };
 
 /**


### PR DESCRIPTION
"One layer of Toxic Spikes causes opposing Pokémon to acquire the Poison status ailment upon switching in, while two or more layers causes opposing Pokémon to become badly poisoned."